### PR TITLE
fix(workspace-group): 调整打开多个工作区情况下初始化逻辑以及修复文章编辑时装饰器位置异常显示问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.0.33
+
+### Patch Changes
+
+- 修复书签移动时出现装饰器位置异常问题
+
 ## 0.0.32
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -145,12 +145,6 @@
         "category": "Bookmark Manager (BM)"
       },
       {
-        "command": "bookmark-manager.addBookmark",
-        "title": "%bookmark-manager.addBookmark%",
-        "icon": "$(diff-insert)",
-        "category": "Bookmark Manager (BM)"
-      },
-      {
         "command": "bookmark-manager.viewAsTree",
         "title": "%bookmark-manager.viewAsTree%",
         "icon": "$(list-tree)",
@@ -627,6 +621,11 @@
           "group": "inline@3"
         },
         {
+          "command": "bookmark-manager.addBookmarkGroup",
+          "when": "view == bookmark-manager && viewItem === workspace",
+          "group": "itemContextGroup@1"
+        },
+        {
           "command": "bookmark-manager.changeBookmarkGroupLabel",
           "when": "view == bookmark-manager && viewItem === custom",
           "group": "inline@1"
@@ -644,12 +643,12 @@
         {
           "command": "bookmark-manager.setAsDefaultActivedGroup",
           "when": "view == bookmark-manager && viewItem === custom",
-          "group": "itemContextGroup@1"
+          "group": "itemContextGroup@2"
         },
         {
           "command": "bookmark-manager.deleteBookmarkGroup",
           "when": "view == bookmark-manager && viewItem === custom",
-          "group": "itemContextGroup@2"
+          "group": "itemContextGroup@3"
         }
       ],
       "commandPalette": [
@@ -671,15 +670,11 @@
         },
         {
           "command": "bookmark-manager.groupedByColor",
-          "when": "false"
+          "when": "true"
         },
         {
           "command": "bookmark-manager.groupedByDefault",
-          "when": "false"
-        },
-        {
-          "command": "bookmark-manager.groupedByWorkspace",
-          "when": "bookmark-manager.multiRootWorkspaces"
+          "when": "true"
         },
         {
           "command": "bookmark-manager.groupedByWorkspace",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bookmark-manager",
   "displayName": "Bookmark Manager (BM)",
   "description": "Simple and easy to use bookmark manager",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "engines": {
     "vscode": "^1.82.0"
   },

--- a/src/commands/bookmark/base.ts
+++ b/src/commands/bookmark/base.ts
@@ -11,7 +11,7 @@ import {
 import {resolveBookmarkController} from '../../bootstrap';
 import resolveServiceManager from '../../services/ServiceManager';
 import {BookmarksGroupedByColorType, IBookmark} from '../../stores';
-import {LineBookmarkContext} from '../../types';
+import {BookmarksGroupedByFileType, LineBookmarkContext} from '../../types';
 import {
   checkIfBookmarksIsInCurrentEditor,
   chooseBookmarkColor,
@@ -221,7 +221,8 @@ export function clearAllBookmarksInCurrentFile(args: any) {
   }
 
   if (args && args.meta) {
-    controller.clearAllBookmarkInFile(args.meta.fileUri);
+    const meta = args.meta as BookmarksGroupedByFileType;
+    controller.clearAllBookmarkInFile(Uri.file(meta.fileId));
   } else {
     const activeEditor = window.activeTextEditor;
     if (!activeEditor) {

--- a/src/providers/BookmarksTreeProvider.ts
+++ b/src/providers/BookmarksTreeProvider.ts
@@ -39,7 +39,7 @@ export class BookmarksTreeProvider extends BaseTreeProvider<
     }
 
     if (viewType === 'tree') {
-      if (groupView === 'default') {
+      if (groupView === 'default' || groupView === 'file') {
         return this.getChildrenByFile(element);
       }
 

--- a/src/stores/bookmark-group.ts
+++ b/src/stores/bookmark-group.ts
@@ -7,24 +7,33 @@ export const BookmarkGroup = types
      * 书签ID
      */
     id: types.string,
+
     /**
      * 书签标签
      */
     label: types.string,
+
     /**
      * 书签在视图中排序索引
      */
     sortedIndex: types.optional(types.number, 0),
+
     /**
      * 书签颜色
      */
     color: types.optional(types.string, DEFAULT_BOOKMARK_GROUP_COLOR),
+
     /**
      * 当前组是否为默认激活的分组
      * - 默认情况下,默认分组为激活状态,其他未非激活状态
      * - 设置为true 的话,默认创建的书签将会放置到激活的分组中
      */
     activeStatus: types.optional(types.boolean, false),
+
+    /**
+     * 保持公共区间的文件夹名称, 以便在多个工作区间中区别
+     */
+    workspace: types.optional(types.string, ''),
   })
   .actions(self => {
     return {

--- a/src/stores/bookmark.ts
+++ b/src/stores/bookmark.ts
@@ -1,4 +1,4 @@
-import {Instance, types} from 'mobx-state-tree';
+import {Instance, SnapshotIn, types} from 'mobx-state-tree';
 import {DEFAULT_BOOKMARK_COLOR} from '../constants';
 import {Selection, Uri, WorkspaceFolder, workspace} from 'vscode';
 import {createHoverMessage} from '../utils';
@@ -89,14 +89,19 @@ export const Bookmark = types
     };
   })
   .actions(self => {
-    function update(bookmarkDto: Partial<Omit<IBookmark, 'id'>>) {
-      Object.keys(bookmarkDto).forEach(it => {
+    function setProp<
+      K extends keyof SnapshotIn<typeof self>,
+      V extends SnapshotIn<typeof self>[K],
+    >(key: K, value: V) {
+      self[key] = value;
+    }
+    function update(dto: Partial<Omit<IBookmark, 'id'>>) {
+      Object.keys(dto).forEach(key => {
         // @ts-ignore
-        if (bookmarkDto[it]) {
-          // @ts-ignore
-          self[it] = bookmarkDto[it];
-        }
+        setProp(key, dto[key]);
       });
+
+      updateRangesOrOptionsHoverMessage();
     }
     function updateRangesOrOptionsHoverMessage() {
       const rangesOrOptions = {...self.rangesOrOptions};
@@ -142,6 +147,7 @@ export const Bookmark = types
     }
 
     return {
+      setProp,
       update,
       updateLabel,
       updateDescription,

--- a/src/types/bookmarks.ts
+++ b/src/types/bookmarks.ts
@@ -36,7 +36,7 @@ export interface IBookmarkStoreInfo {
    */
   groups: Pick<
     IBookmarkGroup,
-    'id' | 'label' | 'sortedIndex' | 'activeStatus'
+    'id' | 'label' | 'sortedIndex' | 'activeStatus' | 'workspace'
   >[];
 }
 

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -1,0 +1,25 @@
+import {l10n, ThemeIcon, window, workspace, WorkspaceFolder} from 'vscode';
+
+/**
+ * 提供一个QuickPick 让用户选择一个工作区
+ * @returns {WorkspaceFolder | undefined}
+ */
+export async function showWorkspaceFolderQuickPick() {
+  const workspaceFolders = workspace.workspaceFolders || [];
+  const pickItems = workspaceFolders.map(folder => ({
+    label: folder.name,
+    description: folder.uri.fsPath,
+    iconPath: ThemeIcon.Folder,
+  }));
+
+  const selectedWorkspaceFolder = await window.showQuickPick(pickItems, {
+    placeHolder: l10n.t('Select a workspace folder'),
+    matchOnDescription: true,
+    matchOnDetail: true,
+  });
+
+  if (!selectedWorkspaceFolder) {
+    return;
+  }
+  return workspaceFolders.find(it => it.name === selectedWorkspaceFolder.label);
+}


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献者指南](./CONTRIBUTING.md)。
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写PR内容：**

- 修复文章编辑时, 书签装饰器位置异常展示问题
- 调整多个工作区间中,初始化树视图逻辑
